### PR TITLE
Do not use minimum-stability:dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,9 @@ Add some vendors to the composer.json as explained here: http://getcomposer.org/
 ```json
 {
     "require": {
-        "contao-community-alliance/composer-installer": "dev-master",
-        "payment/saferpay": "dev-master"
-    },
-    "minimum-stability": "dev"
+        "contao-community-alliance/composer-installer": "dev-master@dev",
+        "payment/saferpay": "dev-master@dev"
+    }
 }
 ```
 

--- a/config/config.php
+++ b/config/config.php
@@ -58,9 +58,8 @@ EOF;
         $strComposerJsonContent = <<<EOF
 {
     "require": {
-        "contao-community-alliance/composer-installer": "dev-master"
-    },
-    "minimum-stability": "dev"
+        "contao-community-alliance/composer-installer": "dev-master@dev"
+    }
 }
 EOF;
 


### PR DESCRIPTION
Using `minimum-stability:dev` will make it nearly impossible to get stable builds of dependencies. Better use `@dev` to set minimum-stability for each dependency.
