### PR TITLE
make release date optional as defined in schema.

### DIFF
--- a/src/system/modules/!composer/languages/de/composer_client.php
+++ b/src/system/modules/!composer/languages/de/composer_client.php
@@ -53,6 +53,7 @@ $GLOBALS['TL_LANG']['composer_client']['not_installed']             = 'Installat
 $GLOBALS['TL_LANG']['composer_client']['install_via']               = 'via %s: %s';
 $GLOBALS['TL_LANG']['composer_client']['dependency_of']             = 'Abhängigkeit von %s';
 $GLOBALS['TL_LANG']['composer_client']['installed_in']              = 'installiert in Version %s';
+$GLOBALS['TL_LANG']['composer_client']['no_releasedate']            = '-';
 
 /**
  * Versions

--- a/src/system/modules/!composer/templates/be_composer_client_install.html5
+++ b/src/system/modules/!composer/templates/be_composer_client_install.html5
@@ -251,7 +251,14 @@ $source = $preferedCandidate->getSourceUrl();
 									echo $reference;
 								}
 							?></span>
-						<span class="release-date"><?php echo $candidate->getReleaseDate()->format($GLOBALS['TL_CONFIG']['datimFormat']); ?></span>
+						<span class="release-date"><?php
+								$relDate = $candidate->getReleaseDate();
+								if ($relDate) {
+									echo $relDate->format($GLOBALS['TL_CONFIG']['datimFormat']);
+								} else {
+									echo $GLOBALS['TL_LANG']['composer_client']['no_releasedate'];
+								}
+							?></span>
 						<span class="license"><?php
 								$license = $candidate->getLicense();
 								if (empty($license)):


### PR DESCRIPTION
The composer repository schema states that the release date of a package is optional.
Before this commit: the Contao composer module would produce a crash in the template.
After this commit: a language string (currently set to "-") will be stated as the release date instead.
