### PR TITLE
fix of 2 bugs when checking VCS requirements

### DIFF
--- a/src/system/modules/!composer/ComposerClientBackend.php
+++ b/src/system/modules/!composer/ComposerClientBackend.php
@@ -1670,7 +1670,7 @@ class ComposerClientBackend extends BackendModule
 		);
 
 		if (is_resource($proc)) {
-			return !proc_close($proc);
+			return proc_close($proc) != -1;
 		}
 
 		return false;

--- a/src/system/modules/!composer/languages/en/composer_client.php
+++ b/src/system/modules/!composer/languages/en/composer_client.php
@@ -115,8 +115,8 @@ $GLOBALS['TL_LANG']['composer_client']['vcs_requirements']            = '
 <li class="{if hgAvailable==true}pass{else}fail{endif}">
 	mercurial is {if hgAvailable==true}available{else}missing, some packages may fail to install!{endif}
 </li>
-<li class="{if svgAvailable==true}pass{else}fail{endif}">
-	svn is {if svgAvailable==true}available{else}missing, some packages may fail to install!{endif}
+<li class="{if svnAvailable==true}pass{else}fail{endif}">
+	svn is {if svnAvailable==true}available{else}missing, some packages may fail to install!{endif}
 </li>
 </ul>
 ';


### PR DESCRIPTION
1. snvAvailable variable was misspelled therefor not found
2. proc_close() sometimes retunres 1 which is OK but  the implementation
   was converting it to false on VCS requirement check. I changed it to
   check if the result is different than -1 which is the only case of error
   according to the documentation:
   http://php.net/manual/en/function.proc-close.php
