### PR TITLE
Contao 4 compatibility

### DIFF
--- a/src/system/modules/!composer/config/autoload.ini
+++ b/src/system/modules/!composer/config/autoload.ini
@@ -1,3 +1,7 @@
+;;
+; Register public folders
+;;
+public[] = "assets"
 
 ;;
 ; Configure what you want the autoload creator to register


### PR DESCRIPTION
Add the `assets/` folder to the list of public folders so it is being symlinked.
