### PR TITLE
Use cURL as default

### DIFF
--- a/src/system/modules/!composer/src/Downloader.php
+++ b/src/system/modules/!composer/src/Downloader.php
@@ -50,7 +50,7 @@ class Downloader
         }
 
         $fileStream = fopen($file, 'wb+');
-        
+
         fwrite($fileStream, file_get_contents($url));
         $headers              = $http_response_header;
         $firstHeaderLine      = $headers[0];


### PR DESCRIPTION
If available, use cURL as default, because it seems to be faster and also works better with proxies (this solution solved some proxy issues for me).

http://stackoverflow.com/questions/5844299/using-file-get-contents-or-curl
