### PR TITLE
fix rename warning on new installation

### DIFF
--- a/src/system/modules/!composer/src/Runtime.php
+++ b/src/system/modules/!composer/src/Runtime.php
@@ -11,6 +11,7 @@
  * @author     Dominik Zogg <dominik.zogg@gmail.com>
  * @author     Oliver Hoff <oliver@hofff.com>
  * @author     Nicky Hoff <nick@hofff.com>
+ * @author     Fritz Michael Gschwantner <fmg@inspiredminds.at>
  * @package    Composer
  * @license    LGPLv3
  * @filesource
@@ -244,7 +245,9 @@ EOF;
         if (is_file($backup)) {
             unlink($backup);
         }
-        rename($file, $backup);
+        if (is_file($file)) {
+            rename($file, $backup);
+        }
         rename($tmpFile, $file);
 
         return true;


### PR DESCRIPTION
When installing the composer-client for the first time, the composer.phar will not be present and thus
```php
rename($file, $backup);
```
will lead to a Warning.
```
Warning: rename(/www/htdocs/w0124b2d/car_2017/composer/composer.phar,/www/htdocs/w0124b2d/car_2017/composer/composer.previous.phar): 
No such file or directory in system/modules/!composer/src/Runtime.php on line 248
```
https://community.contao.org/de/showthread.php?65133-Composer-Installation-Warning-rename&p=428099&highlight=rename#post428099
https://community.contao.org/de/showthread.php?65515-Composer-%C3%BCber-Installtool-in-3-5-24-bringt-Fehler&p=431146&viewfull=1#post431146