### PR TITLE
fix fatal error under PHP 7

### DIFF
--- a/.check-author.yml
+++ b/.check-author.yml
@@ -3,3 +3,9 @@ exclude:
   - tests
 
 mapping:
+  "Fritz Michael Gschwantner <fmg@inspiredminds.at>":
+    - "Fritz Michael Gschwantner <email@spikx.net>"
+    - "Fritz Michael Gschwantner <github@spikx.net>"
+    - "fritzmg <fmg@inspiredminds.at>"
+    - "fritzmg <email@spikx.net>"
+    - "fritzmg <github@spikx.net>"

--- a/src/system/modules/!composer/src/Client.php
+++ b/src/system/modules/!composer/src/Client.php
@@ -8,6 +8,7 @@
  * @copyright  ContaoCommunityAlliance 2013
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Tristan Lins <tristan.lins@bit3.de>
+ * @author     Fritz Michael Gschwantner <fmg@inspiredminds.at>
  * @package    Composer
  * @license    LGPLv3
  * @filesource
@@ -73,7 +74,7 @@ class Client extends \System
         // disable the repo client
         $reset           = false;
         $activeModules   = $this->Config->getActiveModules();
-        $inactiveModules = deserialize($GLOBALS['TL_CONFIG']['inactiveModules']);
+        $inactiveModules = deserialize($GLOBALS['TL_CONFIG']['inactiveModules'], true);
 
         if (in_array('repository', $activeModules)) {
             $inactiveModules[] = 'repository';


### PR DESCRIPTION
## Problem description

Under PHP 7(.1) the following error can occur after installing the composer-client:
```
Fatal error: Uncaught exception Error with message [] operator not supported for strings thrown in C:\Users\Spooky\Documents\VCS\composer-client\src\system\modules\!composer\src\Client.php on line 79

#0 system\modules\core\library\Contao\System.php(340): ContaoCommunityAlliance\Contao\Composer\Client->disableOldClientHook('default', 'en', 'en')
#1 system\modules\core\controllers\BackendInstall.php(43): Contao\System::loadLanguageFile('default')
#2 contao\install.php(23): Contao\BackendInstall->__construct()
#3 {main}
```

## Cause

This is because the line
```php
$inactiveModules = deserialize($GLOBALS['TL_CONFIG']['inactiveModules']);
```
will cause the variable `$inactiveModules` to be a string, if the config variable `inactiveModules` does not exist yet, or if it is empty (`''`). Under PHP 7(.1?) it is illegal to use the `[]` on a string. Previous PHP versions would have automatically converted the empty string to an array.

## Reproduction

1. Use PHP 7.1.1.
2. Remove the `.skip` file under `/system/modules/repository`, if present.
3. Remove the `$GLOBALS['TL_CONFIG']['inactiveModules'] = …` line in the `/system/config/localconfig.php`, if present.
4. Install the `composer-client`, if not already installed.
5. Access the back end.

## Proposed fix

The proposed fix will simply create an empty array, if the deserialized content of the config variable `inactiveModules` is not an array.

## Appendix

* https://community.contao.org/de/showthread.php?65581-Backend-geht-nicht-mehr-seid-Composer-Installation